### PR TITLE
Slim down Docker build stages

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,6 +5,7 @@ ACLOCAL_AMFLAGS = -I m4
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/libs \
     -Wall \
     -Wextra \
+    -Wno-unused-parameter \
     -Wformat-security \
     -D_FORTIFY_SOURCE=2 \
     -fstack-protector \


### PR DESCRIPTION
I removed the step of building the Proxygen library and its dependencies from this repo and moved it to https://github.com/gladiusio/proxygen-env.